### PR TITLE
Add PHP apcu extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM dunglas/frankenphp
 
 RUN install-php-extensions \
+    apcu \
     gd \
     opcache \
     pdo_mysql \


### PR DESCRIPTION
Add apcu extension as Drupal recommends it.

![CleanShot 2022-11-09 at 14 23 26](https://user-images.githubusercontent.com/1140272/200829546-5761c437-682f-4a9f-b318-3be1e5e05096.png)
