### PR TITLE
PostgreSQL with pg_trgm extension

### DIFF
--- a/db.Dockerfile
+++ b/db.Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres
+
+COPY docker-entrypoint-initdb.d/init-pg_trgm-extension.sh /docker-entrypoint-initdb.d/init-pg_trgm-extension.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,9 @@ services:
     restart: always
 
   postgres:
-    image: postgres
+    build:
+      context: .
+      dockerfile: db.Dockerfile
     environment:
       POSTGRES_PASSWORD: example
     restart: always

--- a/docker-entrypoint-initdb.d/init-pg_trgm-extension.sh
+++ b/docker-entrypoint-initdb.d/init-pg_trgm-extension.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+	CREATE EXTENSION pg_trgm;
+EOSQL


### PR DESCRIPTION
- Drupal 9 suggests installing `pg_trgm` extension when using PostgreSQL
- Drupal 10 has it as hard requirement
- This PR uses `db.Dockerfile` to install `pg_trgm` with entrypoint script as instructed in official image instructions
- Use `docker compose build postgres --no-cache` to build it

NOTE! If you have running docker-compose setup maybe with volumes (database initialized), script will not run. They will run only when up'ed fresh

Will resolve #6 