### PR TITLE
Use Drupal 10.0.0-beta2 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,11 @@ COPY --from=drupal /usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/
 
 COPY --from=composer/composer:2-bin /composer /usr/local/bin/
 
-# https://www.drupal.org/node/3060/release
-ENV DRUPAL_VERSION 9.5.0-beta2
+# https://www.drupal.org/project/drupal/releases/10.0.0-beta2
+ENV DRUPAL_VERSION 10.0.0-beta2
 
 WORKDIR /opt/drupal
-# Copy from the official image when drupal 9.5 will be released
+# Copy from the official image when Drupal 10.0 will be released
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \
 	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \


### PR DESCRIPTION
- Use Drupal 10
- [Drupal 10 will be released 14th of December](https://www.drupal.org/about/core/blog/drupal-10-will-be-released-december-14-2022)
- Drupal 10 is based on Symfony 6
- Drupal 9 is still installable with env `DRUPAL_VERSION: 9.5.0-beta2` when building image

Wil resolve #8