### PR TITLE
[WiP] Worker mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,13 @@ COPY --from=composer/composer:2-bin /composer /usr/local/bin/
 ENV DRUPAL_VERSION 10.0.0-beta2
 
 WORKDIR /opt/drupal
+
+COPY composer.json .
+
 # Copy from the official image when Drupal 10.0 will be released
 RUN set -eux; \
 	export COMPOSER_HOME="$(mktemp -d)"; \
-	composer create-project --no-interaction "drupal/recommended-project:$DRUPAL_VERSION" ./; \
+	composer install --no-interaction --no-progress; \
 	chown -R www-data:www-data web/sites web/modules web/themes; \
 	rm -rf /app/public; \
 	ln -sf /opt/drupal/web /app/public; \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the modern app server for PHP.
 ```
 git clone https://github.com/dunglas/frankenphp-drupal
 cd frankenphp-drupal
-docker compose pull --include-deps
+docker compose build --pull
 docker compose up
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,61 @@
+{
+    "name": "dunglas/frankenphp-drupal",
+    "description": "Drupal 10 with FrankenPHP",
+    "type": "project",
+    "license": "MIT",
+    "homepage": "https://github.com/dunglas/frankenphp-drupal",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require": {
+        "php": "^8.2",
+        "composer-runtime-api": "^2",
+        "composer/installers": "^2.0",
+        "drupal/core-composer-scaffold": "^10.0",
+        "drupal/core-recommended": "^10.0",
+        "el7cosmos/drupal-runtime": "*",
+        "runtime/frankenphp-symfony": "^0.1.0"
+    },
+    "conflict": {
+        "drupal/drupal": "*"
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/installers": true,
+            "drupal/core-composer-scaffold": true,
+            "symfony/runtime": true
+        }
+    },
+    "extra": {
+        "drupal-scaffold": {
+            "allowed-packages": [
+                "drupal/core",
+                "el7cosmos/drupal-runtime"
+            ],
+            "locations": {
+                "web-root": "./web"
+            }
+        },
+        "installer-paths": {
+            "web/core": ["type:drupal-core"],
+            "web/libraries/{$name}": ["type:drupal-library", "type:bower-asset", "type:npm-asset"],
+            "web/modules/contrib/{$name}": ["type:drupal-module"],
+            "web/modules/custom/{$name}": ["type:drupal-module-custom"],
+            "web/profiles/{$name}": ["type:drupal-profile"],
+            "web/themes/contrib/{$name}": ["type:drupal-theme"],
+            "web/themes/custom/{$name}": ["type:drupal-theme-custom"],
+            "drush/{$name}": ["type:drupal-drush"]
+        },
+        "runtime": {
+            "autoload_template": "vendor/el7cosmos/drupal-runtime/assets/autoload_runtime.template",
+            "class": "Runtime\\FrankenPhpSymfony\\Runtime"
+        }
+    },
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://packages.drupal.org/8"
+        }
+    ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       # existing content of the image at the same location
       - /app/public/sites
     restart: always
+    environment:
+      FRANKENPHP_CONFIG: "worker ./web/index.php"
 
   postgres:
     build:


### PR DESCRIPTION
- Install with `composer.json`
- Use https://github.com/el7cosmos/drupal-runtime
- `FRANKENPHP_CONFIG` in `docker-compose.yml`
- Updated README.md

Drupal responds with `FRANKENPHP_CONFIG` commented out, otherwise not.

When checking https://localhost headers it seems to responds somewhat but nothing gets to browser:

```
HTTP/1.1 302 Found
Alt-Svc: h3=":443"; ma=2592000
Cache-Control: no-cache, private
Content-Length: 314
Content-Type: text/html; charset=UTF-8
Date: Mon, 14 Nov 2022 05:29:29 GMT
Location: /core/install.php
Server: Caddy
X-Powered-By: PHP/8.2.0RC5
```